### PR TITLE
Add parsed genomebuild to vcf

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# DNAnexus VarDict v1.3.1
+# DNAnexus VarDict v1.3.2
 
 ## What does this app do?
 This app performs variant calling using the VarDict variant caller, calling SNV, MNV, indels (<120 bp default), and complex variants.
@@ -12,7 +12,7 @@ The output vcf will be uploaded into Ingenuity for annotation and filtering.
 ## What inputs are required for this app to run?
 This app requires the following inputs:
 
-- Compressed reference genome including `*.fa` and `*.fa.fai` (`*.tar.gz`).  The file name should be in the format hs37d5.fasta-index.tar.gz so that the genome build can be parsed and added to the VCF header as required when processing with QCI.
+- Compressed reference genome including `*.fa` and `*.fa.fai` (`*.tar.gz`).  The file name should contain the genome build number (37, 19, 38, 20) so that this can be parsed and the appropriate metadata can be added to the VCF header as required when processing with QCI.
 - BAM file(s) (`*.bam`). Multiple BAM files can be provided, producing one VCF per sample (multisample variant calling is not performed).
 - BED file of regions of interest, for filtering output vcf (`*.bed`)
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,13 +1,13 @@
 {
-  "name": "vardict_v1.3.1",
-  "title": "Vardict variant caller v1.3.1",
-  "summary": "v1.3.1 - (VarDict somatic variant caller for use on SWIFT NGS sequencing output).",
+  "name": "vardict_v1.3.2",
+  "title": "Vardict variant caller v1.3.2",
+  "summary": "v1.3.2 - (VarDict somatic variant caller for use on SWIFT NGS sequencing output).",
   "tags": [
     "Variants",
     "Cancer"
   ],
   "properties": {
-    "github release": "v1.3.1"
+    "github release": "v1.3.2"
   },
   "dxapi": "1.0.0",
   "inputSpec": [
@@ -40,7 +40,7 @@
      "help": "The threshold for allele frequency, default: 0.01 or 1% [-f]",
      "class": "string",
      "optional": false,
-     "default": "0.01",      
+     "default": "0.01",
      "group": "Common"
     },
     {
@@ -48,7 +48,7 @@
      "label": "Sample name",
      "help": "Sample name. Will overwrite sample name extracted from bam filenames [-N]",
      "class": "string",
-     "optional": true, 
+     "optional": true,
      "group": "Common"
     },
     {
@@ -56,7 +56,7 @@
      "label": "min variance reads",
      "help": " The minimum # of variant reads, default 2 [-r]",
      "class": "string",
-     "optional": true, 
+     "optional": true,
      "group": "Common"
     },
     {
@@ -64,7 +64,7 @@
      "label": "min reads for strand bias",
      "help": "The minimum # of reads to determine strand bias, default 2 [-B]",
      "class": "string",
-     "optional": true, 
+     "optional": true,
      "group": "Common"
     },
     {
@@ -72,7 +72,7 @@
      "label": "chromosome column",
      "help": "The column for chromosome in bedfile [-c]",
      "class": "string",
-     "optional": false, 
+     "optional": false,
      "default": "1",
      "group": "Common"
     },
@@ -81,7 +81,7 @@
      "label": "region start column",
      "help": "The column for region start in bedfile [-S]",
      "class": "string",
-     "optional": false, 
+     "optional": false,
      "default": "2",
      "group": "Common"
     },
@@ -90,7 +90,7 @@
      "label": "region end column",
      "help": "The column for region end in bedfile [-E]",
      "class": "string",
-     "optional": false, 
+     "optional": false,
      "default": "3",
      "group": "Common"
     },
@@ -99,7 +99,7 @@
      "label": "gene name column",
      "help": "The column for gene name in bedfile [-g]",
      "class": "string",
-     "optional": true, 
+     "optional": true,
      "default": "4",
      "group": "Common"
     },
@@ -109,9 +109,9 @@
      "help": "Perform local realignment.  Default: True.  For Ion or PacBio, 0 is recommended [-k]",
      "class": "boolean",
      "optional": false,
-     "default": true,      
+     "default": true,
      "group": "Common"
-    },  
+    },
     {
       "name": "extra_options",
       "label": "Extra command-line options",

--- a/src/code.sh
+++ b/src/code.sh
@@ -71,7 +71,7 @@ mark-section "Run VarDict Variant Caller"
 for (( i=0; i<${#bam_file_path[@]}; i++ ));
 # show name of current bam file be run
 do echo ${bam_file_prefix[i]}
-# Index bam file input
+# Index bam file inputVardict
 samtools index ${bam_file_path[i]}
 # run Vardict
 /usr/bin/vardict/vardict -G $genome_file -b ${bam_file_path[i]} $opts $bedfile_path | /usr/bin/vardict/teststrandbias.R | /usr/bin/vardict/var2vcf_valid.pl -E -f $allele_freq > ~/out/vardict_vcf/output/${bam_file_prefix[i]}.vardict.vcf

--- a/src/code.sh
+++ b/src/code.sh
@@ -68,14 +68,8 @@ elif [[ $ref_genome_name =~ .*20.* ]]
 then
 	genomebuild="hg20"
 else
-	echo "$ref_genome_name does not contain a parsable reference genome"
+	echo "$ref_genome_name does not contain a parsable reference genome name"
 fi
-
-cd genome
-for file in *
-  do rsync -a "$file" "${file/genome/$genomebuild}"
-  done
-cd ..
 
 genome_file=$(ls genome/*.fa)
 


### PR DESCRIPTION
The script now parses the genome ref name for the build and adds the relevant info to the header of the produced VCF.  This version should be applicable to both the moaONC and mokaAMP pipelines, allowing upload to QCI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/dnanexus_vardict/11)
<!-- Reviewable:end -->
